### PR TITLE
Override docker build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,9 @@ jobs:
     - name: Set CDK_DOCKER environment variable
       run: echo "CDK_DOCKER=/usr/local/bin/cdk_docker.sh" >> $GITHUB_ENV
       
+    - name: Expose GitHub Runtime
+      uses: crazy-max/ghaction-github-runtime@v2
+      
     - name: Run CDK deploy
       run: |
         echo $CDK_DOCKER

--- a/.github/workflows/scripts/cdk_docker.sh
+++ b/.github/workflows/scripts/cdk_docker.sh
@@ -6,6 +6,11 @@ if [[ $1 == "build" ]]; then
   # echo the command before running it
   echo docker buildx "${@:1}" --load
   command docker buildx "${@:1}" --load
+elif [[ $1 == "cp" ]]; then
+  # Add a 'cdk-' prefix to the first of all the remaining arguments
+  # Echo the command before running it
+  echo docker cp "cdk-${2}" "${@:3}"
+  command docker cp "cdk-${2}" "${@:3}"
 else
   # Use docker for all other commands
   # echo the command before running it

--- a/.github/workflows/scripts/cdk_docker.sh
+++ b/.github/workflows/scripts/cdk_docker.sh
@@ -4,8 +4,8 @@
 if [[ $1 == "build" ]]; then
   # Use docker buildx for build commands
   # echo the command before running it
-  echo docker buildx "${@:1}" --load
-  command docker buildx "${@:1}" --load
+  echo docker buildx "${@:1}" --load --cache-to "type=gha,mode=max" --cache-from type=gha
+  command docker buildx "${@:1}" --load --cache-to "type=gha,mode=max" --cache-from type=gha
 else
   # Use docker for all other commands
   # avoid echoing the command because the CDK relies on sdout structure.

--- a/.github/workflows/scripts/cdk_docker.sh
+++ b/.github/workflows/scripts/cdk_docker.sh
@@ -4,8 +4,8 @@
 if [[ $1 == "build" ]]; then
   # Use docker buildx for build commands
   # echo the command before running it
-  echo docker buildx "${@:1}"
-  command docker buildx "${@:1}"
+  echo docker buildx "${@:1}" --load
+  command docker buildx "${@:1}" --load
 else
   # Use docker for all other commands
   # echo the command before running it

--- a/.github/workflows/scripts/cdk_docker.sh
+++ b/.github/workflows/scripts/cdk_docker.sh
@@ -6,14 +6,8 @@ if [[ $1 == "build" ]]; then
   # echo the command before running it
   echo docker buildx "${@:1}" --load
   command docker buildx "${@:1}" --load
-elif [[ $1 == "cp" ]]; then
-  # Add a 'cdk-' prefix to the first of all the remaining arguments
-  # Echo the command before running it
-  echo docker cp "cdk-${2}" "${@:3}"
-  command docker cp "cdk-${2}" "${@:3}"
 else
   # Use docker for all other commands
-  # echo the command before running it
-  echo docker "${@:1}"
+  # avoid echoing the command because the CDK relies on sdout structure.
   command docker "${@:1}"
 fi


### PR DESCRIPTION
I am finalizing an implementation of docker layer caching within a github action when docker is being executed by the [CDK in a specific case.](https://github.com/aws/aws-cdk/blob/f89eb3f6de2d1aea1b4809ea3d749ae1d54f7c6f/packages/aws-cdk-lib/aws-lambda/lib/code.ts#L78) 

The approach here is to override the `docker build` command used by the CDK and make sure that `docker buildx` is run with the right flags to makes use of a github action cache. 

I tested it and it works.

However, it's kind of counterproductive : The goal is to speed up things with caching, but [it apparently is very slow to export an image built with the `docker-container` driver into a docker format. ](https://github.com/emileten/cache-docker-layers-cdk-gha/actions/runs/5240109017/jobs/9460588941#step:11:177), and that step unfortunately does not get cached. See screen below. 

![Screenshot 2023-06-12 at 4 27 41 PM](https://github.com/emileten/cache-docker-layers-cdk-gha/assets/45140658/17079255-bc7d-4321-931a-8232cc9192ff)
